### PR TITLE
Update renovate-bot to ignore Bank of Anthos

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
+  ],
+  "ignorePaths": [
+    "bank-of-anthos/"
   ]
 }


### PR DESCRIPTION
Instead of using `renovate-bot` to manage Bank of Anthos dependencies in this repo, the latest BoA release will be merged monthly.
