### PR TITLE
chore: define security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+## Reporting a Vulnerability
+
+To report a security issue, please use http://g.co/vulnz. We use http://g.co/vulnz for our intake, and do coordination and disclosure here on GitHub (including using GitHub Security Advisory). The Google Security Team will respond within 5 working days of your report on g.co/vulnz.


### PR DESCRIPTION
Use standard Google policy for Github projects